### PR TITLE
[AUT-250] Add js suffix when importing next/dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/nextjs-helpers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "types": "dist/index.d.ts",
   "type": "module",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import dynamic from "next/dynamic";
+import dynamic from "next/dynamic.js";
 import {AuthsignalProviderProps} from "./types";
 
 export const AuthsignalProvider = dynamic<AuthsignalProviderProps>(


### PR DESCRIPTION
- Seems to just be an issue when importing a subfolder within a package directly, e.g. if package is `next` and importing `next/dynamic`, so just specify explicit .js suffix for now even though it's a bit dank